### PR TITLE
Extend import_roots to also automatically include workspace roots.

### DIFF
--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -101,6 +101,13 @@ class PythonArchive(object):
         logging.debug('Compiling file list from [%s]', self.manifest_filename)
         manifest = manifest_parser.parse(self.manifest_filename)
 
+	# Extend the list of import roots to include workspace roots
+	all_import_roots = set(self.import_roots)
+	for path in manifest.iterkeys():
+	    all_import_roots.add(path.split(os.sep)[0])
+	self.import_roots = list(all_import_roots)
+
+
         # Validate manifest and add various extra files to the list
         stored_resources = self.scan_manifest(manifest)
 

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -107,7 +107,6 @@ class PythonArchive(object):
 	    all_import_roots.add(path.split(os.sep)[0])
 	self.import_roots = list(all_import_roots)
 
-
         # Validate manifest and add various extra files to the list
         stored_resources = self.scan_manifest(manifest)
 


### PR DESCRIPTION
This rids the user of having to manually define `imports` field in the BUILD file and have the resulting PAR file have a correct code with all necessary import_roots prepended to it.

It gets the workspace roots from the manifest produced by manifest_parser.

It also makes it irrelevant whether or not the user has set up bazel workspace's name.

PS. I haven't contributed anything via github yet, so please don't assume I know more than what I've just learnt from the FAQ.

Thanks,
Marcin
