### PR TITLE
Extend import_roots to also automatically include workspace roots.

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -61,6 +61,8 @@ def parse_stub(stub_filename):
 
     Returns (list of relative paths, path to Python interpreter)
     """
+
+    # Find the list of import roots
     imports_regex = re.compile(r'''^  python_imports = '([^']*)'$''')
     interpreter_regex = re.compile(r'''^PYTHON_BINARY = '([^']*)'$''')
     import_roots = None
@@ -78,7 +80,8 @@ def parse_stub(stub_filename):
     if import_roots is None or not interpreter:
         raise error.Error('Failed to parse stub file [%s]' % stub_filename)
 
-    # Match the search logic in stub_template.txt
+    # Find the Python interpreter, matching the search logic in
+    # stub_template.txt
     if interpreter.startswith('//'):
         raise error.Error('Python interpreter must not be a label [%s]' %
                           stub_filename)

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -116,8 +116,9 @@ class PythonArchiveTest(unittest.TestCase):
 
     def test_generate_boilerplate(self):
         par = self._construct()
-        boilerplate = par.generate_boilerplate()
+        boilerplate = par.generate_boilerplate(['foo', 'bar'])
         self.assertIn('Boilerplate', boilerplate)
+        self.assertIn("import_roots=['foo', 'bar']", boilerplate)
 
     def test_generate_main(self):
         par = self._construct()
@@ -150,6 +151,12 @@ class PythonArchiveTest(unittest.TestCase):
         resources = par.scan_manifest(manifest)
         self.assertIn('foo.py', resources)
         self.assertIn('bar.py', resources)
+
+    def test_scan_manifest_adds_workspace_roots(self):
+        par = self._construct()
+        manifest = {'foo': None, 'bar/': None, 'baz/quux': None,}
+        resources = par.scan_manifest(manifest)
+        self.assertIn(b"import_roots=['bar', 'baz']", resources['__main__.py'].content)
 
     def test_scan_manifest_adds_main(self):
         par = self._construct()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -103,6 +103,20 @@ par_binary(
     "PY3",
 ]]
 
+[par_binary(
+    name = "package_import_roots/import_roots_%s" % version,
+    srcs = [
+        "package_import_roots/import_roots.py",
+    ],
+    default_python_version = version,
+    imports = ["package_import_roots"],
+    main = "package_import_roots/import_roots.py",
+    srcs_version = "PY2AND3",
+) for version in [
+    "PY2",
+    "PY3",
+]]
+
 # Test targets
 [(
     # Run test without .par file as a control
@@ -141,6 +155,7 @@ par_binary(
     ("version", ":package_f/f", "/package_f/f"),
     ("main_boilerplate", ":package_g/g", "/package_g/g"),
     ("shadow", ":package_shadow/main", "/package_shadow/main"),
+    ("import_roots", ":package_import_roots/import_roots", "/package_import_roots/import_roots"),
 ] for version in [
     "PY2",
     "PY3",

--- a/tests/package_import_roots/import_roots.py
+++ b/tests/package_import_roots/import_roots.py
@@ -1,0 +1,58 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test program for Subpar
+
+Test that sys.path in a .par file has the same items as the Bazel stub.
+
+Given a runfiles that looks like this:
+
+    foo.runfiles/
+        __main__/
+            foo.py
+        other_workspace/
+            bar.py
+
+or
+
+    foo.runfiles/
+        my_workspace/
+            foo.py
+        other_workspace/
+            bar.py
+
+The best way to import bar is by being explicit:
+
+    == foo.py ==
+    from other_workspace import bar
+
+But Bazel sets up the path so that this also works:
+
+    == foo.py ==
+    import bar.py  # Don't do this
+
+This is problematic for the import ambiguity and shadowing issues it
+introduces.  But .par files also allow this behavior for consistency's
+sake.
+
+"""
+
+def main():
+    # This import only works if sys.path contains the 'subpar' directory
+    import tests.package_import_roots
+    print('In import_roots.py main()')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/package_import_roots/import_roots_PY2_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY2_filelist.txt
@@ -1,0 +1,8 @@
+__main__.py
+subpar/__init__.py
+subpar/runtime/__init__.py
+subpar/runtime/support.py
+subpar/tests/__init__.py
+subpar/tests/package_import_roots/__init__.py
+subpar/tests/package_import_roots/import_roots.py
+subpar/tests/package_import_roots/import_roots_PY2

--- a/tests/package_import_roots/import_roots_PY3_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY3_filelist.txt
@@ -1,0 +1,8 @@
+__main__.py
+subpar/__init__.py
+subpar/runtime/__init__.py
+subpar/runtime/support.py
+subpar/tests/__init__.py
+subpar/tests/package_import_roots/__init__.py
+subpar/tests/package_import_roots/import_roots.py
+subpar/tests/package_import_roots/import_roots_PY3


### PR DESCRIPTION
This is based on #13.  I moved the code to a place I felt was slightly better, and added some tests.  Some tweaks were also required for Python3.