### PR TITLE
Fix git_repository example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ designed to work well with [Bazel](http://bazel.io).
 git_repository(
     name = "subpar",
     remote = "https://github.com/google/subpar",
-    tag = "1.0",
-    sha256 = "Fill in sha256 here",
+    tag = "1.0.0",
 )
 ```
 


### PR DESCRIPTION
The 'sha256' attribute is documented but doesn't seem to actually work.