### PR TITLE
Retain Bazel's ordering of Python import paths

### DIFF
--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -183,11 +183,13 @@ class PythonArchive(object):
         """
 
         # Extend the list of import roots to include workspace roots
-        all_import_roots = set(self.import_roots)
+        top_roots = set()
         for stored_path in manifest.keys():
             if '/' in stored_path:  # Zip file paths use / on all platforms
-                all_import_roots.add(stored_path.split('/', 1)[0])
-        import_roots = sorted(all_import_roots)
+                top_dir = stored_path.split('/', 1)[0]
+                if top_dir not in top_roots:
+                    top_roots.add(top_dir)
+        import_roots = list(self.import_roots) + sorted(top_roots)
 
         # Include some files that every .par file needs at runtime
         stored_resources = {}

--- a/test_dir_shadowing/BUILD
+++ b/test_dir_shadowing/BUILD
@@ -1,0 +1,40 @@
+# Integration test for Subpar.
+#
+# This test is not in the `tests` directory because the bug only
+# manifests when the code is in a directory structure rooted at the
+# workspace, and consisting of two direcotories with the same name,
+# E.g. `<workspace>/X/X` for some `X`.
+
+package(default_visibility = ["//tests:__subpackages__"])
+
+load("//:subpar.bzl", "par_binary")
+
+exports_files([
+    "test_dir_shadowing_main_PY2_filelist.txt",
+    "test_dir_shadowing_main_PY3_filelist.txt",
+])
+
+py_library(
+    name = "test_dir_shadowing",
+    srcs = [
+        "test_dir_shadowing/dir_shadowing_lib.py",
+    ],
+    data = [
+        "test_dir_shadowing/dir_shadowing_lib_dat.txt",
+    ],
+    imports = ["."],
+)
+
+par_binary(
+    name = "test_dir_shadowing_main",
+    srcs = [
+        "test_dir_shadowing/dir_shadowing_main.py",
+    ],
+    data = [
+        "test_dir_shadowing/dir_shadowing_main_dat.txt",
+    ],
+    main = "test_dir_shadowing/dir_shadowing_main.py",
+    deps = [
+        ":test_dir_shadowing",
+    ],
+)

--- a/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib.py
+++ b/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib.py
@@ -1,0 +1,26 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test library for Subpar
+
+Regression test for https://github.com/google/subpar/issues/47
+"""
+
+import pkgutil
+
+def lib():
+    print('In dir_shadowing_lib.py lib()')
+    # Test resource extraction
+    lib_dat = pkgutil.get_data('test_dir_shadowing', 'dir_shadowing_lib_dat.txt')
+    assert (lib_dat == b'Dummy data file for dir_shadowing_lib.py\n'), lib_dat

--- a/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
+++ b/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
@@ -1,0 +1,1 @@
+Dummy data file for dir_shadowing_lib.py

--- a/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
+++ b/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
@@ -1,0 +1,33 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test library for Subpar
+
+Regression test for https://github.com/google/subpar/issues/47
+"""
+
+import pkgutil
+
+from test_dir_shadowing import dir_shadowing_lib
+
+def main():
+    print('In dir_shadowing_main.py main()')
+    dir_shadowing_lib.lib()
+    # Test resource extraction
+    dat = pkgutil.get_data('test_dir_shadowing', 'dir_shadowing_main_dat.txt')
+    assert (dat == b'Dummy data file for dir_shadowing_main.py\n'), dat
+
+
+if __name__ == '__main__':
+    main()

--- a/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
+++ b/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
@@ -1,0 +1,1 @@
+Dummy data file for dir_shadowing_main.py

--- a/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
@@ -1,0 +1,11 @@
+__main__.py
+subpar/__init__.py
+subpar/runtime/__init__.py
+subpar/runtime/support.py
+subpar/test_dir_shadowing/__init__.py
+subpar/test_dir_shadowing/test_dir_shadowing/__init__.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
+subpar/test_dir_shadowing/test_dir_shadowing_main

--- a/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
@@ -1,0 +1,11 @@
+__main__.py
+subpar/__init__.py
+subpar/runtime/__init__.py
+subpar/runtime/support.py
+subpar/test_dir_shadowing/__init__.py
+subpar/test_dir_shadowing/test_dir_shadowing/__init__.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
+subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
+subpar/test_dir_shadowing/test_dir_shadowing_main

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -147,13 +147,13 @@ par_binary(
     ("direct_dependency", "//tests/package_b:b", "tests/package_b/b"),
     ("external_workspace", "//tests:package_e/e", "tests/package_e/e"),
     ("import_root", "//tests:package_d/d", "tests/package_d/d"),
-    ("indirect_dependency", "//tests:package_c/c", "tests/package_c/c"),
-    ("main_boilerplate", "//tests:package_g/g", "tests/package_g/g"),
-    ("shadow", "//tests:package_shadow/main", "tests/package_shadow/main"),
     (
         "import_roots",
         "//tests:package_import_roots/import_roots",
         "tests/package_import_roots/import_roots",
     ),
+    ("indirect_dependency", "//tests:package_c/c", "tests/package_c/c"),
+    ("main_boilerplate", "//tests:package_g/g", "tests/package_g/g"),
+    ("shadow", "//tests:package_shadow/main", "tests/package_shadow/main"),
     ("version", "//tests:package_f/f", "tests/package_f/f"),
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -112,10 +112,10 @@ par_binary(
         size = "small",
         srcs = ["test_harness.sh"],
         args = [
-            "tests%s" % path,
+            path,
         ],
         data = [
-            "//tests%s" % label,
+            label,
         ],
     ),
     # Test .par file with harness
@@ -125,26 +125,35 @@ par_binary(
         srcs = ["test_harness.sh"],
         args = [
             "--par",
-            "tests%s.par" % path,
+            "%s.par" % path,
         ] + select({
-            "subpar_test_python_version_3": ["tests%s_PY3_filelist.txt" % path],
-            "//conditions:default": ["tests%s_PY2_filelist.txt" % path],
+            "subpar_test_python_version_3": ["%s_PY3_filelist.txt" % path],
+            "//conditions:default": ["%s_PY2_filelist.txt" % path],
         }),
         data = [
-            "//tests%s.par" % label,
+            "%s.par" % label,
         ] + select({
-            "subpar_test_python_version_3": ["//tests%s_PY3_filelist.txt" % label],
-            "//conditions:default": ["//tests%s_PY2_filelist.txt" % label],
+            "subpar_test_python_version_3": ["%s_PY3_filelist.txt" % label],
+            "//conditions:default": ["%s_PY2_filelist.txt" % label],
         }),
     ),
 ) for name, label, path in [
-    ("basic", "/package_a:a", "/package_a/a"),
-    ("direct_dependency", "/package_b:b", "/package_b/b"),
-    ("indirect_dependency", ":package_c/c", "/package_c/c"),
-    ("import_root", ":package_d/d", "/package_d/d"),
-    ("external_workspace", ":package_e/e", "/package_e/e"),
-    ("version", ":package_f/f", "/package_f/f"),
-    ("main_boilerplate", ":package_g/g", "/package_g/g"),
-    ("shadow", ":package_shadow/main", "/package_shadow/main"),
-    ("import_roots", ":package_import_roots/import_roots", "/package_import_roots/import_roots"),
+    ("basic", "//tests/package_a:a", "tests/package_a/a"),
+    ("direct_dependency", "//tests/package_b:b", "tests/package_b/b"),
+    ("indirect_dependency", "//tests:package_c/c", "tests/package_c/c"),
+    ("import_root", "//tests:package_d/d", "tests/package_d/d"),
+    ("external_workspace", "//tests:package_e/e", "tests/package_e/e"),
+    ("version", "//tests:package_f/f", "tests/package_f/f"),
+    ("main_boilerplate", "//tests:package_g/g", "tests/package_g/g"),
+    ("shadow", "//tests:package_shadow/main", "tests/package_shadow/main"),
+    (
+        "import_roots",
+        "//tests:package_import_roots/import_roots",
+        "tests/package_import_roots/import_roots",
+    ),
+    (
+        "dir_shadowing",
+        "//test_dir_shadowing:test_dir_shadowing_main",
+        "test_dir_shadowing/test_dir_shadowing_main",
+    ),
 ]]

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -83,6 +83,16 @@ par_binary(
 )
 
 par_binary(
+    name = "package_import_roots/import_roots",
+    srcs = [
+        "package_import_roots/import_roots.py",
+    ],
+    imports = ["package_import_roots"],
+    main = "package_import_roots/import_roots.py",
+    srcs_version = "PY2AND3",
+)
+
+par_binary(
     name = "package_shadow/main",
     srcs = [
         "package_shadow/code/__init__.py",
@@ -91,16 +101,6 @@ par_binary(
     ],
     imports = ["package_shadow"],
     main = "package_shadow/main.py",
-    srcs_version = "PY2AND3",
-)
-
-par_binary(
-    name = "package_import_roots/import_roots",
-    srcs = [
-        "package_import_roots/import_roots.py",
-    ],
-    imports = ["package_import_roots"],
-    main = "package_import_roots/import_roots.py",
     srcs_version = "PY2AND3",
 )
 
@@ -139,11 +139,15 @@ par_binary(
     ),
 ) for name, label, path in [
     ("basic", "//tests/package_a:a", "tests/package_a/a"),
+    (
+        "dir_shadowing",
+        "//test_dir_shadowing:test_dir_shadowing_main",
+        "test_dir_shadowing/test_dir_shadowing_main",
+    ),
     ("direct_dependency", "//tests/package_b:b", "tests/package_b/b"),
-    ("indirect_dependency", "//tests:package_c/c", "tests/package_c/c"),
-    ("import_root", "//tests:package_d/d", "tests/package_d/d"),
     ("external_workspace", "//tests:package_e/e", "tests/package_e/e"),
-    ("version", "//tests:package_f/f", "tests/package_f/f"),
+    ("import_root", "//tests:package_d/d", "tests/package_d/d"),
+    ("indirect_dependency", "//tests:package_c/c", "tests/package_c/c"),
     ("main_boilerplate", "//tests:package_g/g", "tests/package_g/g"),
     ("shadow", "//tests:package_shadow/main", "tests/package_shadow/main"),
     (
@@ -151,9 +155,5 @@ par_binary(
         "//tests:package_import_roots/import_roots",
         "tests/package_import_roots/import_roots",
     ),
-    (
-        "dir_shadowing",
-        "//test_dir_shadowing:test_dir_shadowing_main",
-        "test_dir_shadowing/test_dir_shadowing_main",
-    ),
+    ("version", "//tests:package_f/f", "tests/package_f/f"),
 ]]


### PR DESCRIPTION
Fixes #47 