### PR TITLE
Pass use_default_shell_env=True to ctx.action.

### DIFF
--- a/subpar.bzl
+++ b/subpar.bzl
@@ -88,6 +88,7 @@ def _parfile_impl(ctx):
         executable=ctx.executable.compiler,
         arguments=args,
         mnemonic='PythonCompile',
+        use_default_shell_env=True,
     )
 
     # .par file itself has no runfiles and no providers


### PR DESCRIPTION
This is necessary under --python_path=python3 and other relative paths,
which is in turn necessary to support builds across multiple environments
with python3 installed in different locations.

This fixes an error like:

Traceback (most recent call last):
  File "bazel-out/host/bin/external/subpar/compiler/compiler", line 172, in <module>
    Main()
  File "bazel-out/host/bin/external/subpar/compiler/compiler", line 145, in Main
    raise AssertionError('Could not find python binary: ' + PYTHON_BINARY)
AssertionError: Could not find python binary: python3

When running the compiler as a dependency of a par_* rule.