### PR TITLE
Fix tests on MacOS.

### DIFF
--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess
+import sys
 import time
 import unittest
 import zipfile
@@ -45,7 +46,7 @@ class PythonArchiveTest(unittest.TestCase):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
         self.output_filename = os.path.join(self.output_dir, 'output.par')
-        self.interpreter = '/usr/bin/python2'
+        self.interpreter = sys.executable
         self.import_roots = []
         self.date_time_tuple = (1980, 1, 1, 0, 0, 0)
         self.timestamp = 315532800

--- a/tests/test_harness.sh
+++ b/tests/test_harness.sh
@@ -41,7 +41,7 @@ TMP_EXECUTABLE="$TEST_TMPDIR"/$(basename "$EXECUTABLE")
 # Compare list of files in zipfile with expected list
 if [ "$PAR" -eq 1 ]; then
   diff \
-    <(unzip -l "$EXECUTABLE" | awk '{print $NF}' | head -n -2 | tail -n +4) \
+    <(unzip -l -q -q "$EXECUTABLE" | awk '{print $NF}') \
     "$FILELIST" \
     || die 'FATAL: zipfile contents do not match expected'
 fi


### PR DESCRIPTION
Two issues:
 - BSD head/tail don't support the +/- specifications. Use "-q -q" to unzip instead
   to remove headers and footers.
 - "python2" isn't guaranteed to exist. Use the current interpreter.