### PR TITLE
Add no_remove flag

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -84,6 +84,12 @@ def make_command_line_parser():
         'directory at the start of execution.',
         type=bool_from_string,
         required=True)
+    parser.add_argument(
+        '--no_remove',
+        help='Keep extracted files after program finishes if --zip_safe is ' +
+        'enabled.',
+        type=bool_from_string,
+        required=True)
     return parser
 
 
@@ -147,5 +153,6 @@ def main(argv):
         manifest_root=args.manifest_root,
         timestamp=args.timestamp,
         zip_safe=args.zip_safe,
+        no_remove=args.no_remove,
     )
     par.create()

--- a/compiler/cli_test.py
+++ b/compiler/cli_test.py
@@ -38,6 +38,7 @@ class CliTest(unittest.TestCase):
             '--outputpar=baz',
             '--stub_file=quux',
             '--zip_safe=False',
+            '--no_remove=False',
             'foo',
         ])
         self.assertEqual(args.manifest_file, 'bar')

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -47,7 +47,8 @@ from subpar.compiler import stored_resource
 _boilerplate_template = """\
 # Boilerplate added by subpar/compiler/python_archive.py
 from %(runtime_package)s import support as _
-_.setup(import_roots=%(import_roots)s, zip_safe=%(zip_safe)s)
+_.setup(import_roots=%(import_roots)s, zip_safe=%(zip_safe)s,
+    no_remove=%(no_remove)s)
 del _
 # End boilerplate
 """
@@ -101,6 +102,7 @@ class PythonArchive(object):
                  output_filename,
                  timestamp,
                  zip_safe,
+                 no_remove,
                  ):
         self.main_filename = main_filename
 
@@ -113,6 +115,7 @@ class PythonArchive(object):
         t = datetime.utcfromtimestamp(timestamp)
         self.timestamp_tuple = t.timetuple()[0:6]
         self.zip_safe = zip_safe
+        self.no_remove = no_remove
 
         self.compression = zipfile.ZIP_DEFLATED
 
@@ -171,6 +174,7 @@ class PythonArchive(object):
             'runtime_package': _runtime_package,
             'import_roots': str(import_roots),
             'zip_safe': self.zip_safe,
+            'no_remove': self.no_remove,
         }
         return boilerplate_contents.encode('ascii').decode('ascii')
 

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -51,6 +51,7 @@ class PythonArchiveTest(unittest.TestCase):
         self.date_time_tuple = (1980, 1, 1, 0, 0, 0)
         self.timestamp = 315532800
         self.zip_safe = True
+        self.no_remove = False
 
     def _construct(self, manifest_filename=None):
         return python_archive.PythonArchive(
@@ -62,6 +63,7 @@ class PythonArchiveTest(unittest.TestCase):
             output_filename=self.output_filename,
             timestamp=self.timestamp,
             zip_safe=self.zip_safe,
+            no_remove=self.no_remove,
         )
 
     def test_create_manifest_not_found(self):

--- a/docs/subpar.html
+++ b/docs/subpar.html
@@ -140,7 +140,7 @@ specifically need to test a module's behaviour when used in a .par binary.</p>
 
           <h2 id="parfile">parfile</h2>
 
-          <pre>parfile(<a href="#parfile.name">name</a>, <a href="#parfile.src">src</a>, <a href="#parfile.compiler">compiler</a>, <a href="#parfile.default_python_version">default_python_version</a>, <a href="#parfile.imports">imports</a>, <a href="#parfile.main">main</a>, <a href="#parfile.zip_safe">zip_safe</a>)</pre>
+          <pre>parfile(<a href="#parfile.name">name</a>, <a href="#parfile.src">src</a>, <a href="#parfile.compiler">compiler</a>, <a href="#parfile.compiler_args">compiler_args</a>, <a href="#parfile.default_python_version">default_python_version</a>, <a href="#parfile.imports">imports</a>, <a href="#parfile.main">main</a>, <a href="#parfile.no_remove">no_remove</a>, <a href="#parfile.zip_safe">zip_safe</a>)</pre>
 
           <p>A self-contained, single-file Python program, with a .par file extension.</p>
 <p>You probably want to use par_binary() instead of this.</p>
@@ -177,6 +177,13 @@ is a bug, don't use or depend on it.</p>
         <p>Internal use only.</p>
       </td>
     </tr>
+    <tr id="parfile.compiler_args">
+      <td><code>compiler_args</code></td>
+      <td>
+        <p><code>List of strings; Optional; Default is []</code></p>
+        
+      </td>
+    </tr>
     <tr id="parfile.default_python_version">
       <td><code>default_python_version</code></td>
       <td>
@@ -202,6 +209,14 @@ the application.</p>
 <p>See <a href="http://www.bazel.io/docs/be/python.html#py_binary.main">py_binary.main</a></p>
       </td>
     </tr>
+    <tr id="parfile.no_remove">
+      <td><code>no_remove</code></td>
+      <td>
+        <p><code>Boolean; Optional; Default is False</code></p>
+        <p>Whether to keep the extracted temporary directory after the
+program finishes, if zip_safe is enabled.</p>
+      </td>
+    </tr>
     <tr id="parfile.zip_safe">
       <td><code>zip_safe</code></td>
       <td>
@@ -218,7 +233,7 @@ par file executes.</p>
 
           <h2 id="parfile_test">parfile_test</h2>
 
-          <pre>parfile_test(<a href="#parfile_test.name">name</a>, <a href="#parfile_test.src">src</a>, <a href="#parfile_test.compiler">compiler</a>, <a href="#parfile_test.default_python_version">default_python_version</a>, <a href="#parfile_test.imports">imports</a>, <a href="#parfile_test.main">main</a>, <a href="#parfile_test.zip_safe">zip_safe</a>)</pre>
+          <pre>parfile_test(<a href="#parfile_test.name">name</a>, <a href="#parfile_test.src">src</a>, <a href="#parfile_test.compiler">compiler</a>, <a href="#parfile_test.compiler_args">compiler_args</a>, <a href="#parfile_test.default_python_version">default_python_version</a>, <a href="#parfile_test.imports">imports</a>, <a href="#parfile_test.main">main</a>, <a href="#parfile_test.no_remove">no_remove</a>, <a href="#parfile_test.zip_safe">zip_safe</a>)</pre>
 
           <p>Identical to par_binary, but the rule is marked as being a test.</p>
 <p>You probably want to use par_test() instead of this.</p>
@@ -253,6 +268,13 @@ par file executes.</p>
         <p>Internal use only.</p>
       </td>
     </tr>
+    <tr id="parfile_test.compiler_args">
+      <td><code>compiler_args</code></td>
+      <td>
+        <p><code>List of strings; Optional; Default is []</code></p>
+        
+      </td>
+    </tr>
     <tr id="parfile_test.default_python_version">
       <td><code>default_python_version</code></td>
       <td>
@@ -276,6 +298,14 @@ par file executes.</p>
         <p>The name of the source file that is the main entry point of
 the application.</p>
 <p>See <a href="http://www.bazel.io/docs/be/python.html#py_binary.main">py_binary.main</a></p>
+      </td>
+    </tr>
+    <tr id="parfile_test.no_remove">
+      <td><code>no_remove</code></td>
+      <td>
+        <p><code>Boolean; Optional; Default is False</code></p>
+        <p>Whether to keep the extracted temporary directory after the
+program finishes, if zip_safe is enabled.</p>
       </td>
     </tr>
     <tr id="parfile_test.zip_safe">

--- a/docs/subpar.md
+++ b/docs/subpar.md
@@ -94,7 +94,7 @@ specifically need to test a module's behaviour when used in a .par binary.
 ## parfile
 
 <pre>
-parfile(<a href="#parfile.name">name</a>, <a href="#parfile.src">src</a>, <a href="#parfile.compiler">compiler</a>, <a href="#parfile.default_python_version">default_python_version</a>, <a href="#parfile.imports">imports</a>, <a href="#parfile.main">main</a>, <a href="#parfile.zip_safe">zip_safe</a>)
+parfile(<a href="#parfile.name">name</a>, <a href="#parfile.src">src</a>, <a href="#parfile.compiler">compiler</a>, <a href="#parfile.compiler_args">compiler_args</a>, <a href="#parfile.default_python_version">default_python_version</a>, <a href="#parfile.imports">imports</a>, <a href="#parfile.main">main</a>, <a href="#parfile.no_remove">no_remove</a>, <a href="#parfile.zip_safe">zip_safe</a>)
 </pre>
 
 A self-contained, single-file Python program, with a .par file extension.
@@ -136,6 +136,13 @@ is a bug, don't use or depend on it.
         <p>Internal use only.</p>
       </td>
     </tr>
+    <tr id="parfile.compiler_args">
+      <td><code>compiler_args</code></td>
+      <td>
+        <p><code>List of strings; Optional; Default is []</code></p>
+        
+      </td>
+    </tr>
     <tr id="parfile.default_python_version">
       <td><code>default_python_version</code></td>
       <td>
@@ -161,6 +168,14 @@ the application.</p>
 <p>See <a href="http://www.bazel.io/docs/be/python.html#py_binary.main">py_binary.main</a></p>
       </td>
     </tr>
+    <tr id="parfile.no_remove">
+      <td><code>no_remove</code></td>
+      <td>
+        <p><code>Boolean; Optional; Default is False</code></p>
+        <p>Whether to keep the extracted temporary directory after the
+program finishes, if zip_safe is enabled.</p>
+      </td>
+    </tr>
     <tr id="parfile.zip_safe">
       <td><code>zip_safe</code></td>
       <td>
@@ -177,7 +192,7 @@ par file executes.</p>
 ## parfile_test
 
 <pre>
-parfile_test(<a href="#parfile_test.name">name</a>, <a href="#parfile_test.src">src</a>, <a href="#parfile_test.compiler">compiler</a>, <a href="#parfile_test.default_python_version">default_python_version</a>, <a href="#parfile_test.imports">imports</a>, <a href="#parfile_test.main">main</a>, <a href="#parfile_test.zip_safe">zip_safe</a>)
+parfile_test(<a href="#parfile_test.name">name</a>, <a href="#parfile_test.src">src</a>, <a href="#parfile_test.compiler">compiler</a>, <a href="#parfile_test.compiler_args">compiler_args</a>, <a href="#parfile_test.default_python_version">default_python_version</a>, <a href="#parfile_test.imports">imports</a>, <a href="#parfile_test.main">main</a>, <a href="#parfile_test.no_remove">no_remove</a>, <a href="#parfile_test.zip_safe">zip_safe</a>)
 </pre>
 
 Identical to par_binary, but the rule is marked as being a test.
@@ -216,6 +231,13 @@ You probably want to use par_test() instead of this.
         <p>Internal use only.</p>
       </td>
     </tr>
+    <tr id="parfile_test.compiler_args">
+      <td><code>compiler_args</code></td>
+      <td>
+        <p><code>List of strings; Optional; Default is []</code></p>
+        
+      </td>
+    </tr>
     <tr id="parfile_test.default_python_version">
       <td><code>default_python_version</code></td>
       <td>
@@ -239,6 +261,14 @@ You probably want to use par_test() instead of this.
         <p>The name of the source file that is the main entry point of
 the application.</p>
 <p>See <a href="http://www.bazel.io/docs/be/python.html#py_binary.main">py_binary.main</a></p>
+      </td>
+    </tr>
+    <tr id="parfile_test.no_remove">
+      <td><code>no_remove</code></td>
+      <td>
+        <p><code>Boolean; Optional; Default is False</code></p>
+        <p>Whether to keep the extracted temporary directory after the
+program finishes, if zip_safe is enabled.</p>
       </td>
     </tr>
     <tr id="parfile_test.zip_safe">

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -95,7 +95,7 @@ def _find_archive():
     return archive_path
 
 
-def _extract_files(archive_path):
+def _extract_files(archive_path, no_remove):
     """Extract the contents of this .par file to disk.
 
     This creates a temporary directory, and registers an atexit
@@ -107,9 +107,10 @@ def _extract_files(archive_path):
     """
     extract_dir = tempfile.mkdtemp()
 
-    def _extract_files_cleanup():
-        shutil.rmtree(extract_dir, ignore_errors=True)
-    atexit.register(_extract_files_cleanup)
+    if not no_remove:
+        def _extract_files_cleanup():
+            shutil.rmtree(extract_dir, ignore_errors=True)
+        atexit.register(_extract_files_cleanup)
     _log('# extracting %s to %s' % (archive_path, extract_dir))
 
     zip_file = zipfile.ZipFile(archive_path, mode='r')
@@ -282,7 +283,7 @@ def _initialize_import_path(import_roots, import_prefix):
     _log('# adding %s to sys.path' % full_roots)
 
 
-def setup(import_roots, zip_safe):
+def setup(import_roots, zip_safe, no_remove):
     """Initialize subpar run-time support
 
     Args:
@@ -309,7 +310,7 @@ def setup(import_roots, zip_safe):
 
     # Extract files to disk if necessary
     if not zip_safe:
-        extract_dir = _extract_files(archive_path)
+        extract_dir = _extract_files(archive_path, no_remove)
         # sys.path[0] is the name of the executing .par file.  Point
         # it to the extract directory instead, so that Python searches
         # there for imports.

--- a/runtime/support_test.py
+++ b/runtime/support_test.py
@@ -101,7 +101,7 @@ class SupportTest(unittest.TestCase):
 
     def test__extract_files(self):
         # Extract zipfile
-        extract_path = support._extract_files(self.zipfile_name)
+        extract_path = support._extract_files(self.zipfile_name, False)
 
         # Check results
         self.assertTrue(os.path.isdir(extract_path))
@@ -140,7 +140,7 @@ class SupportTest(unittest.TestCase):
             mock_sys_path[0] = self.zipfile_name
             sys.path = mock_sys_path
             success = support.setup(import_roots=['some_root', 'another_root'],
-                                    zip_safe=True)
+                                    zip_safe=True, no_remove=False)
             self.assertTrue(success)
         finally:
             sys.path = old_sys_path
@@ -165,7 +165,8 @@ class SupportTest(unittest.TestCase):
             mock_sys_path = list(sys.path)
             mock_sys_path[0] = self.zipfile_name
             sys.path = mock_sys_path
-            success = support.setup(import_roots=['some_root'], zip_safe=False)
+            success = support.setup(import_roots=['some_root'], zip_safe=False,
+                                    no_remove=False)
             self.assertTrue(success)
         finally:
             sys.path = old_sys_path

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -72,6 +72,7 @@ def _parfile_impl(ctx):
         ]
 
     zip_safe = ctx.attr.zip_safe
+    no_remove = ctx.attr.no_remove
 
     # Assemble command line for .par compiler
     args = ctx.attr.compiler_args + [
@@ -79,6 +80,7 @@ def _parfile_impl(ctx):
         '--outputpar', ctx.outputs.executable.path,
         '--stub_file', stub_file,
         '--zip_safe', str(zip_safe),
+        '--no_remove', str(no_remove),
         main_py_file.path,
     ]
     ctx.action(
@@ -126,6 +128,7 @@ parfile_attrs = {
     ),
     "compiler_args": attr.string_list(default = []),
     "zip_safe": attr.bool(default=True),
+    "no_remove": attr.bool(default=False),
 }
 
 # Rule to create a parfile given a py_binary() as input
@@ -161,6 +164,9 @@ Args:
             extracted to a temporary directory on disk each time the
             par file executes.
 
+  no_remove: Whether to keep the extracted temporary directory after the
+             program finishes, if zip_safe is enabled.
+
 TODO(b/27502830): A directory foo.par.runfiles is also created. This
 is a bug, don't use or depend on it.
 """
@@ -194,6 +200,7 @@ def par_binary(name, **kwargs):
     compiler = kwargs.pop('compiler', None)
     compiler_args = kwargs.pop('compiler_args', [])
     zip_safe = kwargs.pop('zip_safe', True)
+    no_remove = kwargs.pop('no_remove', False)
     native.py_binary(name=name, **kwargs)
 
     main = kwargs.get('main', name + '.py')
@@ -212,6 +219,7 @@ def par_binary(name, **kwargs):
         testonly=testonly,
         visibility=visibility,
         zip_safe=zip_safe,
+        no_remove=no_remove,
     )
 
 def par_test(name, **kwargs):
@@ -222,6 +230,7 @@ def par_test(name, **kwargs):
     """
     compiler = kwargs.pop('compiler', None)
     zip_safe = kwargs.pop('zip_safe', True)
+    no_remove = kwargs.pop('no_remove', False)
     native.py_test(name=name, **kwargs)
 
     main = kwargs.get('main', name + '.py')
@@ -239,4 +248,5 @@ def par_test(name, **kwargs):
         testonly=testonly,
         visibility=visibility,
         zip_safe=zip_safe,
+        no_remove=no_remove,
     )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -94,6 +94,7 @@ par_binary(
     main = "package_extract/extract.py",
     srcs_version = "PY2AND3",
     zip_safe = False,
+    no_remove = False,
 )
 
 par_binary(


### PR DESCRIPTION
This change adds a `no_remove` flag. Its purpose is to let users disable the `atexit` handler that removes the extracted archive when running a `zip_safe=False` parfile.

There's at least two scenarios when this is useful:
 - post mortem analysis of malfunctioning a program/par
 - environments when atexit might be spuriously called (eg. uwsgi workers being killed, while others are still running - I imagine this is due to multiprocessing)

Of course, the flag will cause disk space to get used, and the user needs to be aware of that.