### PR TITLE
Python interpreter can now be overridden

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -60,6 +60,9 @@ def make_command_line_parser():
         '--stub_file',
         help='Read imports and interpreter path from the specified stub file',
         required=True)
+    parser.add_argument(
+        '--interpreter',
+        help='Interpreter to use instead of determining it from the stub file')
     # The default timestamp is "Jan 1 1980 00:00:00 utc", which is the
     # earliest time that can be stored in a zip file.
     #
@@ -137,6 +140,9 @@ def main(argv):
 
     # Parse information from stub file that's too hard to compute in Skylark
     import_roots, interpreter = parse_stub(args.stub_file)
+
+    if args.interpreter:
+        interpreter = args.interpreter
 
     par = python_archive.PythonArchive(
         main_filename=args.main_filename,

--- a/compiler/cli_test.py
+++ b/compiler/cli_test.py
@@ -42,6 +42,19 @@ class CliTest(unittest.TestCase):
         ])
         self.assertEqual(args.manifest_file, 'bar')
 
+      def test_make_command_line_parser_for_interprerter(self):
+         parser = cli.make_command_line_parser()
+         args = parser.parse_args([
+             '--manifest_file=bar',
+             '--manifest_root=bazz',
+             '--outputpar=baz',
+             '--stub_file=quux',
+             '--zip_safe=False',
+             '--interpreter=foobar',
+             'foo',
+         ])
+         self.assertEqual(args.interpreter, 'foobar')
+
     def test_stub(self):
         valid_cases = [
             # Empty list

--- a/compiler/cli_test.py
+++ b/compiler/cli_test.py
@@ -42,18 +42,18 @@ class CliTest(unittest.TestCase):
         ])
         self.assertEqual(args.manifest_file, 'bar')
 
-      def test_make_command_line_parser_for_interprerter(self):
-         parser = cli.make_command_line_parser()
-         args = parser.parse_args([
-             '--manifest_file=bar',
-             '--manifest_root=bazz',
-             '--outputpar=baz',
-             '--stub_file=quux',
-             '--zip_safe=False',
-             '--interpreter=foobar',
-             'foo',
-         ])
-         self.assertEqual(args.interpreter, 'foobar')
+    def test_make_command_line_parser_for_interprerter(self):
+        parser = cli.make_command_line_parser()
+        args = parser.parse_args([
+            '--manifest_file=bar',
+            '--manifest_root=bazz',
+            '--outputpar=baz',
+            '--stub_file=quux',
+            '--zip_safe=False',
+            '--interpreter=foobar',
+            'foo',
+        ])
+        self.assertEqual(args.interpreter, 'foobar')
 
     def test_stub(self):
         valid_cases = [


### PR DESCRIPTION
In case the Python runtime used to build a par is not exactly the same path as the target interpreter, this allows the interpreter to be explicitly set instead of inferred from the stub file.

Example:
```python
par_binary(
    name = "mybinary",
    srcs = ["mybinary.py"],
    compiler_args = ["--interpreter", "/usr/bin/env python3.6"],
)
```