### PR TITLE
Support directories in manifest

### DIFF
--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -233,6 +233,14 @@ class PythonArchive(object):
             if local_path is None:
                 stored_resources[stored_path] = stored_resource.EmptyFile(
                     stored_path, self.timestamp_tuple)
+            elif os.path.isdir(local_path):
+                for local_root, dirs, files in os.walk(local_path):
+                    for f in files:
+                        stored_root = local_root.replace(local_path, stored_path, 1)
+                        stored_fpath = os.path.join(stored_root, f)
+                        local_fpath = os.path.join(local_root, f)
+                        stored_resources[stored_fpath] = stored_resource.StoredFile(
+                            stored_fpath, self.timestamp_tuple, local_fpath)
             else:
                 stored_resources[stored_path] = stored_resource.StoredFile(
                     stored_path, self.timestamp_tuple, local_path)

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -215,6 +216,23 @@ class PythonArchiveTest(unittest.TestCase):
             self.assertEqual(
                 resources['subpar/runtime/support.py'].local_filename,
                 shadowing_support_file.name)
+
+    def test_scan_manifest_directory(self):
+        par = self._construct()
+        try:
+            some_dir = test_utils.temp_dir()
+            with open(os.path.join(some_dir, "foo.py"), "w") as f:
+                f.write("foo\n")
+            with open(os.path.join(some_dir, "bar.py"), "w") as f:
+                f.write("bar\n")
+            manifest = {
+                'somedir': some_dir
+            }
+            resources = par.scan_manifest(manifest)
+            self.assertIn('somedir/foo.py', resources)
+            self.assertIn('somedir/bar.py', resources)
+        finally:
+            shutil.rmtree(some_dir)
 
     def test_write_bootstrap(self):
         par = self._construct()

--- a/compiler/test_utils.py
+++ b/compiler/test_utils.py
@@ -36,3 +36,8 @@ def temp_file(contents, suffix=''):
     t.write(contents)
     t.flush()
     return t
+
+
+def temp_dir():
+    tmpdir = get_test_tmpdir()
+    return tempfile.mkdtemp(dir=tmpdir)


### PR DESCRIPTION
In bazel, a python target may have directory entries in its runfiles
(generated by ctx.actions.declare_directory).  To correctly propagate
those into the par file, add support for directory entries in the
manifest.