### PR TITLE
Fixes for --all_incompatible_changes

### DIFF
--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -30,7 +30,7 @@ py_library(
 py_binary(
     name = "compiler",
     srcs = ["compiler.py"],
-    default_python_version = "PY2",
+    python_version = "PY2",
     main = "compiler.py",
     srcs_version = "PY2AND3",
     deps = [":compiler_lib"],

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -99,7 +99,7 @@ def _parfile_impl(ctx):
     )
 
     # .par file itself has no runfiles and no providers
-    return struct()
+    return []
 
 def _prepend_workspace(path, ctx):
     """Given a path, prepend the workspace name as the parent directory"""


### PR DESCRIPTION
This gets `bazel build //... --all_incompatible_changes` working with Bazel 0.23.

("Diffbased" on #95, but I don't know what the equivalent of diffbase is in github if any. Just ignore the docgen commit in this PR.)

**Edit:** To confirm and save you some time, the content of this PR is just 2 changed lines.