### PR TITLE
Fix incompatibility with Python Toolchains

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -53,7 +53,7 @@ def make_command_line_parser():
         help='Root directory of all relative paths in manifest file.',
         default=os.getcwd())
     parser.add_argument(
-        '--outputpar',
+        '--output_par',
         help='Filename of generated par file.',
         required=True)
     parser.add_argument(
@@ -91,7 +91,8 @@ def make_command_line_parser():
         '--import_root',
         help='Path to add to sys.path, may be repeated to provide multiple roots.',
         action='append',
-        default=[])
+        default=[],
+        dest='import_roots')
     return parser
 
 
@@ -148,9 +149,9 @@ def main(argv):
 
     par = python_archive.PythonArchive(
         main_filename=args.main_filename,
-        import_roots=args.import_root,
+        import_roots=args.import_roots,
         interpreter=interpreter,
-        output_filename=args.outputpar,
+        output_filename=args.output_par,
         manifest_filename=args.manifest_file,
         manifest_root=args.manifest_root,
         timestamp=args.timestamp,

--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -69,7 +69,7 @@ def make_command_line_parser():
     # "Seconds since Unix epoch" was chosen to be compatible with
     # the SOURCE_DATE_EPOCH standard
     #
-    # Numeric calue is from running this:
+    # Numeric value is from running this:
     #   "date --date='Jan 1 1980 00:00:00 utc' --utc +%s"
     parser.add_argument(
         '--timestamp',

--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -115,12 +115,18 @@ def parse_stub(stub_filename):
         raise error.Error('Failed to parse stub file [%s]' % stub_filename)
 
     # Find the Python interpreter, matching the search logic in
-    # stub_template.txt
+    # stub_template.txt and checking for default toolchain
     if interpreter.startswith('//'):
         raise error.Error('Python interpreter must not be a label [%s]' %
                           stub_filename)
     elif interpreter.startswith('/'):
         pass
+    elif interpreter == 'bazel_tools/tools/python/py3wrapper.sh': # Default toolchain
+        # Replace default toolchain python3 wrapper with default python3 on path
+        interpreter = '/usr/bin/env python3'
+    elif interpreter == 'bazel_tools/tools/python/py2wrapper.sh': # Default toolchain
+        # Replace default toolchain python2 wrapper with default python2 on path
+        interpreter = '/usr/bin/env python2'
     elif '/' in interpreter:
         pass
     else:

--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -140,7 +140,7 @@ def main(argv):
     parser = make_command_line_parser()
     args = parser.parse_args(argv[1:])
 
-    # Parse interpreter from stub file that's not available in Skylark
+    # Parse interpreter from stub file that's not available in Starlark
     interpreter = parse_stub(args.stub_file)
 
     if args.interpreter:

--- a/compiler/cli_test.py
+++ b/compiler/cli_test.py
@@ -70,11 +70,6 @@ class CliTest(unittest.TestCase):
 PYTHON_BINARY = '/usr/bin/python'
 """,
              '/usr/bin/python'],
-            # Relative path to interpreter
-            [b"""
-PYTHON_BINARY = 'mydir/python'
-""",
-             'mydir/python'],
             # Search for interpreter on $PATH
             [b"""
 PYTHON_BINARY = 'python'
@@ -97,10 +92,11 @@ PYTHON_BINARY = 'bazel_tools/tools/python/py2wrapper.sh'
                 self.assertEqual(actual, expected)
 
         invalid_cases = [
+            # No interpreter
             b'',
             b'\n\n',
-            # No interpreter
-            b"  python_imports = 'myworkspace/spam/eggs'",
+            # Relative interpreter path
+            b"PYTHON_BINARY = 'mydir/python'",
             # Interpreter is label
             b"""
 PYTHON_BINARY = '//mypackage:python'

--- a/compiler/cli_test.py
+++ b/compiler/cli_test.py
@@ -35,7 +35,7 @@ class CliTest(unittest.TestCase):
         args = parser.parse_args([
             '--manifest_file=bar',
             '--manifest_root=bazz',
-            '--outputpar=baz',
+            '--output_par=baz',
             '--stub_file=quux',
             '--zip_safe=False',
             '--import_root=root1',
@@ -44,10 +44,10 @@ class CliTest(unittest.TestCase):
         ])
         self.assertEqual(args.manifest_file, 'bar')
         self.assertEqual(args.manifest_root, 'bazz')
-        self.assertEqual(args.outputpar, 'baz')
+        self.assertEqual(args.output_par, 'baz')
         self.assertEqual(args.stub_file, 'quux')
         self.assertEqual(args.zip_safe, False)
-        self.assertEqual(args.import_root, ['root1', 'root2'])
+        self.assertEqual(args.import_roots, ['root1', 'root2'])
         self.assertEqual(args.main_filename, 'foo')
 
     def test_make_command_line_parser_for_interprerter(self):
@@ -55,7 +55,7 @@ class CliTest(unittest.TestCase):
         args = parser.parse_args([
             '--manifest_file=bar',
             '--manifest_root=bazz',
-            '--outputpar=baz',
+            '--output_par=baz',
             '--stub_file=quux',
             '--zip_safe=False',
             '--interpreter=foobar',

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -30,6 +30,7 @@ See also https://www.python.org/dev/peps/pep-0441/
 
 from datetime import datetime
 import contextlib
+import errno
 import io
 import logging
 import os
@@ -290,9 +291,14 @@ class PythonArchive(object):
 
 
 def remove_if_present(filename):
-    """Delete any existing file"""
-    if os.path.exists(filename):
+    """Delete a file if it exists"""
+    try:
+        # Remove atomically
         os.remove(filename)
+    except OSError as exc:
+        # Ignore failure if file does not exist
+        if exc.errno != errno.ENOENT:
+            raise
 
 
 def fetch_support_file(name, timestamp_tuple):

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -78,7 +78,7 @@ def _parfile_impl(ctx):
     args = ctx.attr.compiler_args + [
         "--manifest_file",
         sources_file.path,
-        "--outputpar",
+        "--output_par",
         ctx.outputs.executable.path,
         "--stub_file",
         ctx.attr.src.files_to_run.executable.path,

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -64,8 +64,7 @@ def _parfile_impl(ctx):
     )
 
     # Find the list of directories to add to sys.path
-    # TODO(b/29227737): Use 'imports' provider from Bazel
-    stub_file = ctx.attr.src.files_to_run.executable.path
+    import_roots = ctx.attr.src[PyInfo].imports.to_list()
 
     # Inputs to the action, but don't actually get stored in the .par file
     extra_inputs = [
@@ -82,11 +81,15 @@ def _parfile_impl(ctx):
         "--outputpar",
         ctx.outputs.executable.path,
         "--stub_file",
-        stub_file,
+        ctx.attr.src.files_to_run.executable.path,
         "--zip_safe",
         str(zip_safe),
-        main_py_file.path,
     ]
+    for import_root in import_roots:
+        args.extend(['--import_root', import_root])
+    args.append(main_py_file.path)
+
+    # Run compiler
     ctx.actions.run(
         inputs = inputs + extra_inputs,
         tools = [ctx.attr.src.files_to_run.executable],


### PR DESCRIPTION
Fixes #98 by detecting the default toolchain wrappers and replacing with env versions. I'm perhaps not totally happy with how it's done, as any change in the path to these wrappers would break things again, so open to suggestions. Also, for Python 2 should we use `/usr/bin/python` or `/usr/bin/python2`, I prefer the latter but don't know how this behaves on all systems?

Also, now that we have PyInfo provider, the import paths are passed directly from Starlark to the compiler, removing a bit of fragility in parsing the stub file for those. However, I can't see a way to pass the interpreter directly, as this doesn't appear to be available to Starlark. This removed a TODO with reference `b/29227737`, if that means anything internally?

Tested with both the default toolchain and a custom one to ensure the correct shebang ends up at the top of the par file. It might be worth adding a test that excercises this, but until the toolchains flag is flipped in CI the test will always fail.