### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ designed to work well with [Bazel](https://bazel.build/).
 * Add the following to your WORKSPACE file:
 
 ```python
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "subpar",
     remote = "https://github.com/google/subpar",


### PR DESCRIPTION
git_repository is not a built-in command for the latest versions of Bazel.