### PR TITLE
Remove specific release tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ designed to work well with [Bazel](https://bazel.build/).
 git_repository(
     name = "subpar",
     remote = "https://github.com/google/subpar",
-    tag = "1.0.0",
+    tag = "<latest>",
 )
 ```
 


### PR DESCRIPTION
The WORKSPACE git_repository listing has a stale release tag. We could likely *try* to keep it up to date, but that would likely be a pain. Instead, use a bogus tag like "<latest>" because then it will fail if the user doesn't overwrite it. Otherwise it won't fail and users will just be using an old version.