### PR TITLE
Load Python rules from bazelbuild/rules_python

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,17 @@ MIN_BAZEL_VERSION = "0.23.0"
 # Because tests require --incompatible_use_python_toolchains.
 MIN_BAZEL_VERSION_FOR_TESTS = "0.25.0"
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "6c5f479420b0a086e3bc7a6d7c818196d0c89ad8",  # 2019-08-02
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
 # Used by integration tests
 local_repository(
     name = "test_workspace",

--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -1,8 +1,9 @@
 # Utility for creating self-contained python executables.
 
-package(default_visibility = ["//visibility:public"])
-
+load("@rules_python//python:defs.bzl", "py_library", "py_binary", "py_test")
 load("//:subpar.bzl", "parfile")
+
+package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "compiler_lib",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -47,18 +47,18 @@ function set_toolchain_hook {
   fi
 
   cat > toolchain_test_hook.bzl << EOF
-load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+load("@rules_python//python:defs", "py_runtime", "py_runtime_pair")
 
 PYVER = "$pyver"
 
 def define_toolchain_for_testing():
-    native.py_runtime(
+    py_runtime(
         name = "py2_runtime",
         interpreter_path = "$py2_path",
         python_version = "PY2",
     )
 
-    native.py_runtime(
+    py_runtime(
         name = "py3_runtime",
         interpreter_path = "$py3_path",
         python_version = "PY3",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -47,7 +47,7 @@ function set_toolchain_hook {
   fi
 
   cat > toolchain_test_hook.bzl << EOF
-load("@rules_python//python:defs", "py_runtime", "py_runtime_pair")
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 
 PYVER = "$pyver"
 

--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 package(default_visibility = ["//compiler:__pkg__"])
 
 py_library(

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -14,6 +14,8 @@
 
 """Build self-contained python executables."""
 
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+
 DEFAULT_COMPILER = "//compiler:compiler.par"
 
 def _parfile_impl(ctx):
@@ -204,7 +206,7 @@ def par_binary(name, **kwargs):
     compiler = kwargs.pop("compiler", None)
     compiler_args = kwargs.pop("compiler_args", [])
     zip_safe = kwargs.pop("zip_safe", True)
-    native.py_binary(name = name, **kwargs)
+    py_binary(name = name, **kwargs)
 
     main = kwargs.get("main", name + ".py")
     imports = kwargs.get("imports")
@@ -232,7 +234,7 @@ def par_test(name, **kwargs):
     """
     compiler = kwargs.pop("compiler", None)
     zip_safe = kwargs.pop("zip_safe", True)
-    native.py_test(name = name, **kwargs)
+    py_test(name = name, **kwargs)
 
     main = kwargs.get("main", name + ".py")
     imports = kwargs.get("imports")

--- a/test_dir_shadowing/BUILD
+++ b/test_dir_shadowing/BUILD
@@ -5,9 +5,10 @@
 # workspace, and consisting of two direcotories with the same name,
 # E.g. `<workspace>/X/X` for some `X`.
 
-package(default_visibility = ["//tests:__subpackages__"])
-
+load("@rules_python//python:defs.bzl", "py_library")
 load("//:subpar.bzl", "par_binary")
+
+package(default_visibility = ["//tests:__subpackages__"])
 
 exports_files([
     "test_dir_shadowing_main_PY2_filelist.txt",

--- a/tests/package_a/BUILD
+++ b/tests/package_a/BUILD
@@ -1,8 +1,9 @@
 # Test package for Subpar
 
-package(default_visibility = ["//tests:__subpackages__"])
-
+load("@rules_python//python:defs.bzl", "py_library")
 load("//:subpar.bzl", "par_binary")
+
+package(default_visibility = ["//tests:__subpackages__"])
 
 exports_files([
     "a_PY2_filelist.txt",

--- a/tests/test_workspace/BUILD
+++ b/tests/test_workspace/BUILD
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
-
+load("@rules_python//python:defs.bzl", "py_library")
 load("@subpar//:subpar.bzl", "par_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["data_file.txt"])
 

--- a/tests/test_workspace/WORKSPACE
+++ b/tests/test_workspace/WORKSPACE
@@ -1,1 +1,12 @@
 workspace(name = "test_workspace")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "6c5f479420b0a086e3bc7a6d7c818196d0c89ad8",  # 2019-08-02
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()

--- a/third_party/pypi__portpicker_1_2_0/BUILD
+++ b/third_party/pypi__portpicker_1_2_0/BUILD
@@ -1,5 +1,7 @@
 # Test package for Subpar
 
+load("@rules_python//python:defs.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(

--- a/third_party/pypi__portpicker_1_2_0/WORKSPACE
+++ b/third_party/pypi__portpicker_1_2_0/WORKSPACE
@@ -1,1 +1,12 @@
 workspace(name = "pypi__portpicker_1_2_0")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "6c5f479420b0a086e3bc7a6d7c818196d0c89ad8",  # 2019-08-02
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()

--- a/third_party/pypi__yapf_0_19_0/BUILD
+++ b/third_party/pypi__yapf_0_19_0/BUILD
@@ -1,5 +1,7 @@
 # Test package for Subpar
 
+load("@rules_python//python:defs.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(

--- a/third_party/pypi__yapf_0_19_0/WORKSPACE
+++ b/third_party/pypi__yapf_0_19_0/WORKSPACE
@@ -1,1 +1,12 @@
 workspace(name = "pypi__yapf_0_19_0")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "6c5f479420b0a086e3bc7a6d7c818196d0c89ad8",  # 2019-08-02
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()


### PR DESCRIPTION
This migrates subpar for bazelbuild/bazel#9006. Note that it adds a dependency
on bazelbuild/rules_python, which means that these two repositories now have a
dependency cycle.

WORKSPACE and BUILD files in tests are also updated for the same.