### PR TITLE
Use a different directory to extract pars

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -137,8 +137,10 @@ for PYTHON_INTERPRETER in "${PYTHON2}" "${PYTHON3}"; do
   if [ -z "${PYTHON_INTERPRETER}" ] ; then
     continue;
   fi
-
-  BAZEL_TEST="bazel test --test_output=errors \
+  PAR_DIRECTORY=$HOME/.pex/par
+  mkdir -p ${PAR_DIRECTORY}
+  BAZEL_TEST="bazel test --sandbox_tmpfs_path=${PAR_DIRECTORY} \
+--test_output=errors \
 --incompatible_use_python_toolchains \
 --extra_toolchains=//tests:toolchain_for_testing"
   if [ "${PYTHON_INTERPRETER}" = "${PYTHON3}" ]; then

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -62,6 +62,7 @@ import warnings
 import zipfile
 import zipimport
 
+PAR_DIRECTORY = os.path.join(os.path.expanduser("~"), '.pex', 'par')
 
 def _log(msg):
     """Print a debugging message in the same format as python -vv output"""
@@ -105,7 +106,10 @@ def _extract_files(archive_path):
     Returns:
         Directory where contents were extracted to.
     """
-    extract_dir = tempfile.mkdtemp()
+
+    if not os.path.exists(PAR_DIRECTORY):
+        os.makedirs(PAR_DIRECTORY)
+    extract_dir = tempfile.mkdtemp(prefix='bazel_', dir=PAR_DIRECTORY)
 
     def _extract_files_cleanup():
         shutil.rmtree(extract_dir, ignore_errors=True)


### PR DESCRIPTION
Use ~/.par/pex instead of /tmp to extract pars.
Stale folders are left behind if the par enters
a crash loop and this can affect normal operations
if /tmp gets full.