### PR TITLE
Don't parse stub file if interpreter is explicitly provided

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -58,7 +58,7 @@ def make_command_line_parser():
         required=True)
     parser.add_argument(
         '--stub_file',
-        help='Read imports and interpreter path from the specified stub file',
+        help='Read interpreter path from the specified stub file',
         required=True)
     parser.add_argument(
         '--interpreter',
@@ -156,10 +156,7 @@ def main(argv):
     args = parser.parse_args(argv[1:])
 
     # Parse interpreter from stub file that's not available in Starlark
-    interpreter = parse_stub(args.stub_file)
-
-    if args.interpreter:
-        interpreter = args.interpreter
+    interpreter = args.interpreter or parse_stub(args.stub_file)
 
     par = python_archive.PythonArchive(
         main_filename=args.main_filename,

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -208,6 +208,7 @@ def par_binary(name, **kwargs):
     """
     compiler = kwargs.pop("compiler", None)
     compiler_args = kwargs.pop("compiler_args", [])
+    interpreter = kwargs.pop("interpreter", None)
     zip_safe = kwargs.pop("zip_safe", True)
     py_binary(name = name, **kwargs)
 
@@ -222,6 +223,7 @@ def par_binary(name, **kwargs):
         compiler_args = compiler_args,
         default_python_version = default_python_version,
         imports = imports,
+        interpreter = interpreter,
         main = main,
         name = name + ".par",
         src = name,
@@ -238,6 +240,7 @@ def par_test(name, **kwargs):
     specifically need to test a module's behaviour when used in a .par binary.
     """
     compiler = kwargs.pop("compiler", None)
+    interpreter = kwargs.pop("interpreter", None)
     zip_safe = kwargs.pop("zip_safe", True)
     py_test(name = name, **kwargs)
 
@@ -251,6 +254,7 @@ def par_test(name, **kwargs):
         compiler = compiler,
         default_python_version = default_python_version,
         imports = imports,
+        interpreter = interpreter,
         main = main,
         name = name + ".par",
         src = name,

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -89,6 +89,8 @@ def _parfile_impl(ctx):
     ]
     for import_root in import_roots:
         args.extend(['--import_root', import_root])
+    if ctx.attr.interpreter:
+        args.extend(['--interpreter', ctx.attr.interpreter])
     args.append(main_py_file.path)
 
     # Run compiler
@@ -137,6 +139,7 @@ parfile_attrs = {
         cfg = "host",
     ),
     "compiler_args": attr.string_list(default = []),
+    "interpreter": attr.string(),
     "zip_safe": attr.bool(default = True),
 }
 


### PR DESCRIPTION
It seems like `--stub_file` is only parsed to derive which interpreter is being used. Correct me if I'm wrong, but it seems like passing in `--interpreter` should short-circuit parsing that file. Seems like this will allow for using in-workspace `py_runtime` definitions as long as the interpreter is specified explicitly in the `parfile()` rule.

I might be missing some important context though.