### PR TITLE
Use interpreter specified in arguments before parsing stub files

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -155,11 +155,11 @@ def main(argv):
     parser = make_command_line_parser()
     args = parser.parse_args(argv[1:])
 
-    # Parse interpreter from stub file that's not available in Starlark
-    interpreter = parse_stub(args.stub_file)
-
     if args.interpreter:
         interpreter = args.interpreter
+    else:
+        # Parse interpreter from stub file that's not available in Starlark
+        interpreter = parse_stub(args.stub_file)
 
     par = python_archive.PythonArchive(
         main_filename=args.main_filename,


### PR DESCRIPTION
The pull request changes the order of the interpreter argument check and parsing a stub file: if the interpreter argument is specified  in the command line than don't parse the stub file that prevents failing at https://github.com/google/subpar/blob/df97c29b/compiler/cli.py#L143-L146 if the interpreter argument is specified